### PR TITLE
fix: Save the settings in a sub group named transition_qgis

### DIFF
--- a/login_dialog.py
+++ b/login_dialog.py
@@ -28,6 +28,7 @@ from qgis.PyQt.QtWidgets import QDialog
 import os
 import requests
 from pyTransition import Transition
+from .settings_constant import TOKEN_KEY, URL_KEY, USERNAME_KEY, KEEP_CONNECTION_KEY
 
 class LoginDialog(QDialog):
     """
@@ -70,10 +71,10 @@ class LoginDialog(QDialog):
             transition_instance = Transition(self.urlEdit.text(), self.usernameEdit.text(), self.passwordEdit.text())
             self.transitionInstanceCreated.emit(transition_instance)
 
-            self.settings.setValue("username", self.usernameEdit.text())
-            self.settings.setValue("url", self.urlEdit.text())
-            self.settings.setValue("token", transition_instance.token)
-            self.settings.setValue("keepConnection", self.loginCheckbox.isChecked())
+            self.settings.setValue(USERNAME_KEY, self.usernameEdit.text())
+            self.settings.setValue(URL_KEY, self.urlEdit.text())
+            self.settings.setValue(TOKEN_KEY, transition_instance.token)
+            self.settings.setValue(KEEP_CONNECTION_KEY, self.loginCheckbox.isChecked())
             
             self.accept()
             

--- a/settings_constant.py
+++ b/settings_constant.py
@@ -1,0 +1,29 @@
+# MIT License
+
+# Copyright (c) 2024 Polytechnique Montréal
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Constants for the settings specific to this plugin. They are in a subgroup of
+# the QGIS settings called transition_qgis
+
+TOKEN_KEY = "transition_qgis/token"
+URL_KEY = "transition_qgis/url"
+USERNAME_KEY = "transition_qgis/username"
+KEEP_CONNECTION_KEY = "transition_qgis/keepConnection"

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -24,6 +24,7 @@ from qgis.core import *
 from qgis.PyQt.QtWidgets import QWidget, QFormLayout, QLabel, QLineEdit, QVBoxLayout
 
 from pyTransition import Transition
+from .settings_constant import TOKEN_KEY, URL_KEY, USERNAME_KEY, KEEP_CONNECTION_KEY
 
 class SettingsDialog(QWidget):
     """
@@ -49,7 +50,7 @@ class SettingsDialog(QWidget):
         self.usernameOrEmailLabel = QLabel(self.tr("Username or email"))
         self.usernameOrEmailLabel.setMinimumSize(50,40)
 
-        self.username = self.settings.value("username")
+        self.username = self.settings.value(USERNAME_KEY)
         self.usernameField = QLineEdit()
         self.usernameField.setText(self.username)
         self.usernameField.setReadOnly(True)
@@ -58,7 +59,7 @@ class SettingsDialog(QWidget):
         self.urlLabel = QLabel(self.tr("Transition server URL"))
         self.urlLabel.setMinimumSize(50,40)
 
-        self.url = self.settings.value("url")
+        self.url = self.settings.value(URL_KEY)
         self.urlField = QLineEdit()
         self.urlField.setText(self.url)
         self.urlField.setReadOnly(True)

--- a/transition_qgis.py
+++ b/transition_qgis.py
@@ -41,6 +41,7 @@ from .route_form import RouteForm
 from .accessibility_form import AccessibilityForm
 from .settings_dialog import SettingsDialog
 from .transit_info_panel import TransitInformationPanel
+from .settings_constant import TOKEN_KEY, URL_KEY, USERNAME_KEY, KEEP_CONNECTION_KEY
 
 class TransitionWidget:
     """QGIS Plugin Implementation."""
@@ -238,9 +239,9 @@ class TransitionWidget:
 
     def checkValidLogin(self):
         """Check if there is a login token in the settings"""
-        token = self.settings.value("token")
+        token = self.settings.value(TOKEN_KEY)
         if token:
-            transition_instance = Transition(self.settings.value("url"), None, None, token)
+            transition_instance = Transition(self.settings.value(URL_KEY), None, None, token)
             if transition_instance.is_token_valid():
                 self.transition_instance = transition_instance
                 return True
@@ -587,7 +588,7 @@ class TransitionWidget:
             This method disconnects the user from the Transition server and displays the login dialog.
         """
         # Remove user settings
-        if self.settings.value("keepConnection") !=  Qt.CheckState.Checked:
+        if self.settings.value(KEEP_CONNECTION_KEY) !=  Qt.CheckState.Checked:
             self.removeSettings()
         
         self.dockwidget.close()
@@ -600,10 +601,10 @@ class TransitionWidget:
         """
             Remove the user settings from the QGIS settings.
         """
-        self.settings.remove("token")
-        self.settings.remove("url")
-        self.settings.remove("username")
-        self.settings.remove("keepConnection")
+        self.settings.remove(TOKEN_KEY)
+        self.settings.remove(URL_KEY)
+        self.settings.remove(USERNAME_KEY)
+        self.settings.remove(KEEP_CONNECTION_KEY)
 
     def setLayerOpacity(self, layer, opacity):
         """


### PR DESCRIPTION
fixes #19

Add a file with the name of the settings keys, add them in a subgroup called `transition_qgis` and update the calls to the settings to use those constants.