### PR TITLE
fix: Make sure settings are kept when disconnecting/closing

### DIFF
--- a/login_dialog.py
+++ b/login_dialog.py
@@ -51,7 +51,10 @@ class LoginDialog(QDialog):
         self.iface = iface
         self.show()
 
-        self.urlEdit.setText("http://localhost:8080")
+        self.usernameEdit.setText(self.settings.value(USERNAME_KEY, ""))
+        self.urlEdit.setText(self.settings.value(URL_KEY, "http://localhost:8080"))
+        # In the settings file, it seems to be 'true' as string, but during a session, it is a boolean
+        self.loginCheckbox.setChecked(self.settings.value(KEEP_CONNECTION_KEY, False, type=bool))
 
         self.buttonBox.accepted.connect(self.onConnectButtonClicked)
         self.buttonBox.rejected.connect(self.reject)

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -24,7 +24,7 @@ from qgis.core import *
 from qgis.PyQt.QtWidgets import QWidget, QFormLayout, QLabel, QLineEdit, QVBoxLayout
 
 from pyTransition import Transition
-from .settings_constant import TOKEN_KEY, URL_KEY, USERNAME_KEY, KEEP_CONNECTION_KEY
+from .settings_constant import URL_KEY, USERNAME_KEY
 
 class SettingsDialog(QWidget):
     """

--- a/transition_qgis.py
+++ b/transition_qgis.py
@@ -201,7 +201,7 @@ class TransitionWidget:
     def onClosePlugin(self):
         """Cleanup necessary items here when plugin dockwidget is closed"""
         # Remove user settings
-        if not self.settings.value('keepConnection'):
+        if not self.settings.value(KEEP_CONNECTION_KEY, False, type=bool):
             self.removeSettings()
 
         # Disconnect
@@ -588,7 +588,7 @@ class TransitionWidget:
             This method disconnects the user from the Transition server and displays the login dialog.
         """
         # Remove user settings
-        if self.settings.value(KEEP_CONNECTION_KEY) !=  Qt.CheckState.Checked:
+        if not self.settings.value(KEEP_CONNECTION_KEY, False, type=bool):
             self.removeSettings()
         
         self.dockwidget.close()


### PR DESCRIPTION
fixes #28

Also fill the login widgets with the previous settings

Add a function to convert a settings value to boolean, as boolean values in the settings file are kept as 'true'/'false' strings.