### PR TITLE
fix: Do not send negative values for first waiting time

### DIFF
--- a/route_form.py
+++ b/route_form.py
@@ -101,11 +101,11 @@ class RouteForm(QWidget):
         self.maxTransferWaitTimeChoice.setMaximum(20)
         self.maxTransferWaitTimeChoice.setToolTip(self.tr("To avoid long calculation time, this value has a maximum of 20 minutes."))
 
-        self.maxWaitTimeFisrstStopLabel = CustomLabel(self.tr("Maximum first waiting time (minutes)"))
-        self.maxWaitTimeFisrstStopChoice = QSpinBox()
-        self.maxWaitTimeFisrstStopChoice.setMinimum(-1)
-        self.maxWaitTimeFisrstStopChoice.setValue(-1)
-        self.maxWaitTimeFisrstStopChoice.setToolTip(self.tr("If waiting time at first stop is greater than this value for a line, ignore the departure of this line at this stop. Use -1 to ignore this field and allow for indefinite waiting."))
+        self.maxWaitTimeFirstStopLabel = CustomLabel(self.tr("Maximum first waiting time (minutes)"))
+        self.maxWaitTimeFirstStopChoice = QSpinBox()
+        self.maxWaitTimeFirstStopChoice.setMinimum(-1)
+        self.maxWaitTimeFirstStopChoice.setValue(-1)
+        self.maxWaitTimeFirstStopChoice.setToolTip(self.tr("If waiting time at first stop is greater than this value for a line, ignore the departure of this line at this stop. Use -1 to ignore this field and allow for indefinite waiting."))
 
         self.scenarioLabel = CustomLabel(self.tr("Scenario"))
         self.scenarioChoice = QComboBox()
@@ -120,8 +120,8 @@ class RouteForm(QWidget):
         self.routeName = QLineEdit()
 
         # Add fields to form display
-        for label, field in zip([self.modeLabel, self.departureOrArrivalLabel,self.departureOrArrivalTimeLabel,self.routeNameLabel, self.maxParcoursTimeLabel, self.minWaitTimeLabel, self.maxAccessTimeOrigDestLabel, self.maxTransferWaitTimeLabel, self.maxWaitTimeFisrstStopLabel, self.scenarioLabel, self.withAlternativeLabel], 
-                                [self.modeChoice, self.radioButtonsWidget, self.departureOrArrivalTime, self.routeName, self.maxParcoursTimeChoice, self.minWaitTimeChoice, self.maxAccessTimeOrigDestChoice, self.maxTransferWaitTimeChoice, self.maxWaitTimeFisrstStopChoice, self.scenarioChoice, self.withAlternativeChoice]):
+        for label, field in zip([self.modeLabel, self.departureOrArrivalLabel,self.departureOrArrivalTimeLabel,self.routeNameLabel, self.maxParcoursTimeLabel, self.minWaitTimeLabel, self.maxAccessTimeOrigDestLabel, self.maxTransferWaitTimeLabel, self.maxWaitTimeFirstStopLabel, self.scenarioLabel, self.withAlternativeLabel], 
+                                [self.modeChoice, self.radioButtonsWidget, self.departureOrArrivalTime, self.routeName, self.maxParcoursTimeChoice, self.minWaitTimeChoice, self.maxAccessTimeOrigDestChoice, self.maxTransferWaitTimeChoice, self.maxWaitTimeFirstStopChoice, self.scenarioChoice, self.withAlternativeChoice]):
             label.setWordWrap(True)
             row_layout = QHBoxLayout()
             row_layout.addWidget(label, stretch=4)  # 66% of the space

--- a/transition_qgis.py
+++ b/transition_qgis.py
@@ -383,6 +383,7 @@ class TransitionWidget:
                 QMessageBox.warning(self.dockwidget, self.tr("No modes selected"), self.tr("Please select at least one mode."))
                 return
  
+            maxFirstWaitingTime = self.createRouteForm.maxWaitTimeFirstStopChoice.value()
             result = self.transition_instance.request_routing_result(
                 modes=modes, 
                 origin=[self.selectedCoords['routeOriginPoint'].x(), self.selectedCoords['routeOriginPoint'].y()], 
@@ -394,7 +395,8 @@ class TransitionWidget:
                 max_access_time_minutes=self.createRouteForm.maxAccessTimeOrigDestChoice.value(), 
                 departure_or_arrival_time=self.createRouteForm.departureOrArrivalTime.time().toPyTime(), 
                 departure_or_arrival_choice="Departure" if self.createRouteForm.departureRadioButton.isChecked() else "Arrival", 
-                max_first_waiting_time_minutes=self.createRouteForm.maxWaitTimeFisrstStopChoice.value(),
+                # If the user didn't specify a maximum first waiting time, set it to a high value (10000 minutes) to wait indefinitely
+                max_first_waiting_time_minutes=maxFirstWaitingTime if maxFirstWaitingTime >= 0 else 10000,
                 with_geojson=True,
                 with_alternatives=self.createRouteForm.withAlternativeChoice.isChecked()
             )["result"]


### PR DESCRIPTION
fixes #35

The returned value is 10000 minutes, which is almost 7 days, enough to represent illimited wait in terms of transit.

Also fix typo in widget names Fisrst => First